### PR TITLE
Patches: Splash as plugin: Example Plugin (does nothing)

### DIFF
--- a/gosh.go
+++ b/gosh.go
@@ -41,7 +41,6 @@ func New() *Goshell {
 // Init initializes the shell with the given context
 func (gosh *Goshell) Init(ctx context.Context) error {
 	gosh.ctx = ctx
-	gosh.printSplash()
 	return gosh.loadCommands()
 }
 
@@ -83,24 +82,6 @@ func (gosh *Goshell) loadCommands() error {
 		gosh.ctx = context.WithValue(gosh.ctx, "gosh.commands", gosh.commands)
 	}
 	return nil
-}
-
-// TODO delegate splash to a plugin
-func (gosh *Goshell) printSplash() {
-	fmt.Println(`	
-                        888      
-                        888      
-                        888      
- .d88b.  .d88b. .d8888b 88888b.  
-d88P"88bd88""88b88K     888 "88b 
-888  888888  888"Y8888b.888  888 
-Y88b 888Y88..88P     X88888  888 
- "Y88888 "Y88P"  88888P'888  888 
-     888                         
-Y8b d88P                         
- "Y88P"
- 
- `)
 }
 
 // Open opens the shell for the given reader
@@ -196,7 +177,7 @@ func main() {
 
 	shell := New()
 	if err := shell.Init(ctx); err != nil {
-		fmt.Print("\n\nfailed to initialize:", err)
+		fmt.Println("\n\nfailed to initialize:\n", err)
 		os.Exit(1)
 	}
 

--- a/plugins/00_splash.go
+++ b/plugins/00_splash.go
@@ -14,7 +14,20 @@ type splashCmds struct{}
 
 func (t *splashCmds) Init(ctx context.Context) error {
 	// to set your splash, modify the text in the println statement below, multiline is supported
-	fmt.Println(`-------------------------`)
+	fmt.Println(`		
+                        888      	
+                        888      	
+                        888      	
+ .d88b.  .d88b. .d8888b 88888b.  	
+d88P"88bd88""88b88K     888 "88b 	
+888  888888  888"Y8888b.888  888 	
+Y88b 888Y88..88P     X88888  888 	
+ "Y88888 "Y88P"  88888P'888  888 	
+     888                         	
+Y8b d88P                         	
+ "Y88P"	
+ 	
+ `)
 
 	return nil
 }

--- a/plugins/00_splash.go
+++ b/plugins/00_splash.go
@@ -6,7 +6,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/Merith-TK/gosh/api"
+	"github.com/vladimirvivien/gosh/api"
 )
 
 type splashCmd string

--- a/plugins/00_splash.go
+++ b/plugins/00_splash.go
@@ -1,0 +1,26 @@
+package main
+
+// this is on the back burner, not needed at the moment
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/Merith-TK/gosh/api"
+)
+
+type splashCmd string
+type splashCmds struct{}
+
+func (t *splashCmds) Init(ctx context.Context) error {
+	// to set your splash, modify the text in the println statement below, multiline is supported
+	fmt.Println(`-------------------------`)
+
+	return nil
+}
+
+func (t *splashCmds) Registry() map[string]api.Command {
+	return map[string]api.Command{}
+}
+
+var Commands splashCmds

--- a/plugins/example-plugin.cmd.go
+++ b/plugins/example-plugin.cmd.go
@@ -1,0 +1,59 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"io"
+
+	"github.com/vladimirvivien/gosh/api"
+)
+
+// Make sure to replace `exampleCmd` with
+// what ever you want, but make sure it
+// does not clash with existing plugins,
+
+// # MULTIPLE COMMANDS CAN BE DECLARED IN
+// # THE SAME PLUGIN, see testcmd.go for
+// # an example
+
+type exampleCmd string
+
+// for plugins that dont contain a command to
+// load, all lines marked with //OP are optional
+// if your plugin adds a command, please fille these out
+func (t exampleCmd) Name() string      { return string(t) }                //OP
+func (t exampleCmd) Usage() string     { return `example` }                //OP
+func (t exampleCmd) ShortDesc() string { return `description of example` } //OP
+func (t exampleCmd) LongDesc() string  { return t.ShortDesc() }            //OP
+func (t exampleCmd) Exec(ctx context.Context, args []string) (context.Context, error) {
+
+	// Put your custom programming here, make sure to
+	// accept and parse the args variable if you need
+	// to!
+
+	return ctx, nil
+}
+
+type exampleCmds struct{}
+
+func (t *exampleCmds) Init(ctx context.Context) error {
+	out := ctx.Value("gosh.stdout").(io.Writer)
+
+	// If you want something to happen when the module
+	// loads, put it here,
+
+	fmt.Fprintln(out, "example module loaded OK")
+	return nil
+}
+
+func (t *exampleCmds) Registry() map[string]api.Command {
+	return map[string]api.Command{
+		"example": exampleCmd("example"), //OP
+	}
+}
+
+var Commands exampleCmds
+
+// If your plugin needs extra functions, declare
+// them down here to call upon, or import their
+// library.


### PR DESCRIPTION
This PR delegates the splashscreen to a plugin
and adds an example plugin that does nothing but explain how to make another plugin